### PR TITLE
fail example

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,11 +36,11 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}  
 
     # Install Docker Compose
-    - name: Install Docker Compose
-      run: |
-        sudo curl -L "https://github.com/docker/compose/releases/download/$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r .tag_name)/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-        sudo chmod +x /usr/local/bin/docker-compose
-        docker-compose --version  # Verify installation
+    # - name: Install Docker Compose
+    #   run: |
+    #     sudo curl -L "https://github.com/docker/compose/releases/download/$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r .tag_name)/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    #     sudo chmod +x /usr/local/bin/docker-compose
+    #     docker-compose --version  # Verify installation
     
     # Set up Docker Compose
     - name: Set up Docker Compose


### PR DESCRIPTION
讓building失敗的方法: 註解掉安裝 `docker-compose` 的指令，因此無法執行後續的docker build